### PR TITLE
check if slaves are MINAS or not

### DIFF
--- a/ethercat_manager/include/ethercat_manager/ethercat_manager.h
+++ b/ethercat_manager/include/ethercat_manager/ethercat_manager.h
@@ -137,6 +137,7 @@ private:
 
   const std::string ifname_;
   uint8_t iomap_[4096];
+  int num_clients_;
   boost::thread cycle_thread_;
   mutable boost::mutex iomap_mutex_;
   bool stop_flag_;

--- a/ethercat_manager/src/ethercat_manager.cpp
+++ b/ethercat_manager/src/ethercat_manager.cpp
@@ -167,6 +167,7 @@ namespace ethercat {
 
 EtherCatManager::EtherCatManager(const std::string& ifname)
   : ifname_(ifname), 
+    num_clients_(0),
     stop_flag_(false)
 {
   if (initSoem(ifname)) 
@@ -231,7 +232,12 @@ bool EtherCatManager::initSoem(const std::string& ifname) {
   {
     // MINAS-A5B Serial Man = 066Fh, ID = [5/D]****[0/4/8][0-F]*
     printf(" Man: %8.8x ID: %8.8x Rev: %8.8x %s\n", (int)ec_slave[cnt].eep_man, (int)ec_slave[cnt].eep_id, (int)ec_slave[cnt].eep_rev, IF_MINAS(ec_slave[cnt])?" MINAS Drivers":"");
+    if(IF_MINAS(ec_slave[cnt])) {
+      num_clients_++;
+    }
   }
+  printf("Found %d MINAS Drivers\n", num_clients_);
+
 
   /*
     SET PDO maping 4    SX-DSV02470 p.52
@@ -390,7 +396,7 @@ bool EtherCatManager::initSoem(const std::string& ifname) {
 
 int EtherCatManager::getNumClinets() const
 {
-  return ec_slavecount;
+  return num_clients_;
 }
 
 void EtherCatManager::write(int slave_no, uint8_t channel, uint8_t value)


### PR DESCRIPTION
for https://github.com/tork-a/minas/issues/34

これでうまくいくか自信なし．
上のdiffをみたらわかるけど、
```
  if (ec_config_init(FALSE) <= 0)
```
とかでネットワークに付いている全部のslave情報をもってきている．

```
  if (ec_statecheck(0, EC_STATE_PRE_OP, EC_TIMEOUTSTATE*4) != EC_STATE_PRE_OP)
```
とかで、デバイスのモードをpre_operation に変更とかしている．
前にエラーになっているのは、`  // extend PDO mapping 4 see p. 53 of SX-DSV02470 ` というところで、PDOマッピングというのをかえていて、これは明らかにminas依存なので、continueして飛ばしているから大丈夫だと思うけど、上のstatecheckとかを全デバイスで行うので、別につけたデバイスに問題はないのか、というのが気になる所．

そこで詰まると、結構厄介な問題かも．
そもそも、この追加でつけたデバイスを、どうやって制御したいんだろう、というのもある、EtherCATって複数のマスタをおけるのかな？
とすると、そおそもネットワークをわけたほうがいいんじゃないの、とかおもったり．
