### PR TITLE
enable to publish actual position/velocity/torque value as /diagnostics

### DIFF
--- a/ethercat_manager/include/ethercat_manager/ethercat_manager.h
+++ b/ethercat_manager/include/ethercat_manager/ethercat_manager.h
@@ -132,6 +132,11 @@ public:
    */
   int getNumClinets() const;
 
+  /**
+   * \brief get the status of clients
+   */
+  void getStatus(int slave_no, std::string &name, int &eep_man, int &eep_id, int &eep_rev, int &obits, int &ibits, int &state, int &pdelay, int &hasdc, int &activeports, int &configadr) const;
+
 private:
   bool initSoem(const std::string& ifname);
 

--- a/ethercat_manager/src/ethercat_manager.cpp
+++ b/ethercat_manager/src/ethercat_manager.cpp
@@ -399,6 +399,25 @@ int EtherCatManager::getNumClinets() const
   return num_clients_;
 }
 
+void EtherCatManager::getStatus(int slave_no, std::string &name, int &eep_man, int &eep_id, int &eep_rev, int &obits, int &ibits, int &state, int &pdelay, int &hasdc, int &activeports, int &configadr) const
+{
+  if (slave_no > ec_slavecount) {
+    fprintf(stderr, "ERROR : slave_no(%d) is larger than ec_slavecount(%d)\n", slave_no, ec_slavecount);
+    exit(1);
+  }
+  name = std::string(ec_slave[slave_no].name);
+  eep_man = (int)ec_slave[slave_no].eep_man;
+  eep_id  = (int)ec_slave[slave_no].eep_id;
+  eep_rev = (int)ec_slave[slave_no].eep_rev;
+  obits   = ec_slave[slave_no].Obits;
+  ibits   = ec_slave[slave_no].Ibits;
+  state   = ec_slave[slave_no].state;
+  pdelay  = ec_slave[slave_no].pdelay;
+  hasdc   = ec_slave[slave_no].hasdc;
+  activeports = ec_slave[slave_no].activeports;
+  configadr   = ec_slave[slave_no].configadr;
+}
+
 void EtherCatManager::write(int slave_no, uint8_t channel, uint8_t value)
 {
   boost::mutex::scoped_lock lock(iomap_mutex_);

--- a/minas_control/include/minas_control/minas_hardware_interface.h
+++ b/minas_control/include/minas_control/minas_hardware_interface.h
@@ -40,11 +40,16 @@ namespace minas_control
 struct JointData
 {
   std::string name_;
+  std::string hardware_id_;
   double cmd_;
   double pos_;
   double vel_;
   double eff_;
   int home_encoder_offset_;
+  // Input
+  uint32 position_actual_value;		// 6064h : Position actual value
+  uint32 velocity_actual_value;		// 606Ch : Velocity actual value
+  uint16 torque_actual_value;		// 6077h : Torque actual value
 };
 
 class JointControlInterface
@@ -68,6 +73,18 @@ class JointControlInterface
   virtual void read() = 0;
   virtual void write() = 0;
   virtual void shutdown() = 0;
+
+  void getInputActualValueToStatus(std::string &joint_name,
+                                   std::string &hardware_id,
+                                   uint32 &position_actual_value,
+                                   uint32 &velocity_actual_value,
+                                   uint16 &torque_actual_value) {
+    joint_name = joint.name_;
+    hardware_id = joint.hardware_id_;
+    position_actual_value = joint.position_actual_value;
+    velocity_actual_value = joint.velocity_actual_value;
+    torque_actual_value = joint.torque_actual_value;
+  }
 
   protected:
     JointData joint;
@@ -131,6 +148,11 @@ public:
   ros::Time getTime();
   ros::Duration getPeriod();
 
+  int getInputActualValueToStatus(std::vector<std::string> &joint_names,
+                                  std::vector<std::string> &hardware_ids,
+                                  std::vector<uint32> &position_actual_values,
+                                  std::vector<uint32> &velocity_actual_values,
+                                  std::vector<uint16> &torque_actual_values);
   void getParamFromROS(int joint_no, int &torque_for_emergency_stop, int &over_load_level, int &over_speed_level, double &motor_working_range, int &max_motor_speed, int &max_torque, int &home_encoder_offset);
 };
 

--- a/minas_control/src/minas_hardware_interface.cpp
+++ b/minas_control/src/minas_hardware_interface.cpp
@@ -31,7 +31,17 @@ namespace minas_control
 
   EtherCATJointControlInterface::EtherCATJointControlInterface(ethercat::EtherCatManager* manager, int slave_no, hardware_interface::JointStateInterface& jnt_stat, hardware_interface::PositionJointInterface& jnt_cmd, int torque_for_emergency_stop, int over_load_level, int over_speed_level, double motor_working_range, int max_motor_speed, int max_torque, int home_encoder_offset) : JointControlInterface(slave_no, jnt_stat, jnt_cmd)
   {
-    ROS_INFO("Initialize EtherCATJoint (%d)", slave_no);
+    std::string name;
+    int eep_man, eep_id, eep_rev;
+    int obits, ibits, state, pdelay, hasdc;
+    int activeports, configadr;
+    manager->getStatus(slave_no, name, eep_man, eep_id, eep_rev, obits, ibits, state, pdelay, hasdc, activeports, configadr);
+    //
+    std::stringstream ss;
+    ss << name << "(" << configadr << ")";
+    joint.hardware_id_ = ss.str();
+
+    ROS_INFO("Initialize EtherCATJoint (%d) %s(man:%x, id:%x, rev:%x, port:%x, addr:%x)", slave_no, name.c_str(), eep_man, eep_id, eep_rev, activeports, configadr);
     // EtherCAT
     int operation_mode = 0x08; // (csp) cyclic synchronous position mode
 
@@ -145,6 +155,9 @@ namespace minas_control
     joint.pos_ = int32_t(input.position_actual_value - joint.home_encoder_offset_) / PULSE_PER_REVOLUTE;
     joint.vel_ = int32_t(input.velocity_actual_value) / PULSE_PER_REVOLUTE;
     joint.eff_ = int32_t(input.torque_actual_value) / PULSE_PER_REVOLUTE;
+    joint.position_actual_value = input.position_actual_value;
+    joint.velocity_actual_value = input.velocity_actual_value;
+    joint.torque_actual_value = input.torque_actual_value;
   }
 
   void EtherCATJointControlInterface::write()
@@ -163,6 +176,9 @@ namespace minas_control
     joint.pos_ = joint.cmd_;
     joint.vel_ = 0;
     joint.eff_ = 0;
+    joint.position_actual_value = 0;
+    joint.velocity_actual_value = 0;
+    joint.torque_actual_value = 0;
   }
 
   void DummyJointControlInterface::write()
@@ -279,6 +295,30 @@ namespace minas_control
     BOOST_FOREACH (JointControlInterface* control, controls) {
       control->write();
     }
+  }
+
+  int MinasHardwareInterface::getInputActualValueToStatus(std::vector<std::string> &joint_names,
+                                                          std::vector<std::string> &hardware_ids,
+                                                          std::vector<uint32> &position_actual_values,
+                                                          std::vector<uint32> &velocity_actual_values,
+                                                          std::vector<uint16> &torque_actual_values)
+  {
+    int n_dof = 0;
+    BOOST_FOREACH (JointControlInterface* control, controls) {
+      std::string joint_name;
+      std::string hardware_id;
+      uint32 position_actual_value;
+      uint32 velocity_actual_value;
+      uint16 torque_actual_value;
+      control->getInputActualValueToStatus(joint_name, hardware_id, position_actual_value, velocity_actual_value, torque_actual_value);
+      joint_names.push_back(joint_name);
+      hardware_ids.push_back(hardware_id);
+      position_actual_values.push_back(position_actual_value);
+      velocity_actual_values.push_back(velocity_actual_value);
+      torque_actual_values.push_back(torque_actual_value);
+      n_dof++;
+    }
+    return n_dof;
   }
 
   inline ros::Time MinasHardwareInterface::getTime()

--- a/minas_control/src/minas_hardware_interface.cpp
+++ b/minas_control/src/minas_hardware_interface.cpp
@@ -61,6 +61,9 @@ namespace minas_control
     ROS_INFO("Initialize EtherCATJoint (readInputs)");
     input = client->readInputs();
     int32 current_position = input.position_actual_value;
+    ROS_INFO("                         (PositionActualValue %d)", input.position_actual_value);
+    ROS_INFO("                         (VelocityActualValue %d)", input.velocity_actual_value);
+    ROS_INFO("                         (TorqueActualValue   %d)", input.torque_actual_value);
 
     ROS_INFO("Initialize EtherCATJoint (set target position)");
     // set target position


### PR DESCRIPTION
this will publish diagnostics like 
```
header: 
  seq: 5
  stamp: 
    secs: 1518330705
    nsecs: 762791152
  frame_id: ''
status: 
  - 
    level: 0
    name: Input Actual Values (joint1)
    message: OK
    hardware_id: MADHT1105B01(4097)
    values: 
      - 
        key: Postion Actual Value
        value: 925052
      - 
        key: Velocity Actual Value
        value: 0
      - 
        key: Torque Actual Value
        value: 0
  - 
    level: 0
    name: Input Actual Values (joint2)
    message: OK
    hardware_id: ''
    values: 
```
