### PR TITLE
Fix simple test without arguments

### DIFF
--- a/minas_control/src/simple_test.cpp
+++ b/minas_control/src/simple_test.cpp
@@ -39,7 +39,7 @@ void help() {
 int main(int argc, char *argv[])
 {
   int operation_mode = 0x01; // (pp) position profile mode
-  std::string ifname;
+  std::string ifname = "eth0";
 
   printf("MINAS Simple Test using SOEM (Simple Open EtherCAT Master)\n");
   while (1) {

--- a/minas_control/src/simple_test.cpp
+++ b/minas_control/src/simple_test.cpp
@@ -27,6 +27,15 @@ void timespecInc(struct timespec &tick, int nsec)
     }
 }
 
+void help() {
+  fprintf(stderr, "Usage: simple_test [options]\n");
+  fprintf(stderr, "  Available options\n");
+  fprintf(stderr, "    -i, --interface     NIC interface name for EtherCAT network\n");
+  fprintf(stderr, "    -p, --position_mode Sample program using Position Profile (pp) mode (Default)\n");
+  fprintf(stderr, "    -c, --cycliec_mode  Sample program using cyclic synchronous position(csp) mode\n");
+  fprintf(stderr, "    -h, --help          Print this message and exit\n");
+}
+
 int main(int argc, char *argv[])
 {
   int operation_mode = 0x01; // (pp) position profile mode
@@ -45,12 +54,7 @@ int main(int argc, char *argv[])
     if (c == -1) break;
     switch (c) {
     case 'h':
-      fprintf(stderr, "Usage: simple_test [options]\n");
-      fprintf(stderr, "  Available options\n");
-      fprintf(stderr, "    -i, --interface     NIC interface name for EtherCAT network\n");
-      fprintf(stderr, "    -p, --position_mode Sample program using Position Profile (pp) mode (Default)\n");
-      fprintf(stderr, "    -c, --cycliec_mode  Sample program using cyclic synchronous position(csp) mode\n");
-      fprintf(stderr, "    -h, --help          Print this message and exit\n");
+      help();
       exit(0);
       break;
     case 'p':
@@ -64,6 +68,7 @@ int main(int argc, char *argv[])
       break;
     }
   }
+  try {
   /* start slaveinfo */
   ethercat::EtherCatManager manager(ifname);
   std::vector<minas_control::MinasClient *> clients;
@@ -202,6 +207,9 @@ int main(int argc, char *argv[])
       client->printPDSOperation(input);
       client->servoOff();
     }
+  } catch ( ... ) {
+    help();
+  }
 
   printf("End program\n");
 


### PR DESCRIPTION
when we run `simple_test` without any argument, it fails as follows, and I always spent a few second to realize that I forget to add `-i ethX`,
```
$ rosrun minas_control simple_test
MINAS Simple Test using SOEM (Simple Open EtherCAT Master)
Initializing etherCAT master
wkc = -1
No slaves found on
terminate called after throwing an instance of 'ethercat::EtherCatError'
what():  Could not initialize SOEM
Aborted (core dumped)
```
Form this change, we can get
```
$ rosrun minas_control simple_test
MINAS Simple Test using SOEM (Simple Open EtherCAT Master)
Initializing etherCAT master
wkc = -1
No slaves found on eth0
Usage: simple_test [options]
Available options
-i, --interface     NIC interface name for EtherCAT network
-p, --position_mode Sample program using Position Profile (pp) mode (Default)
-c, --cycliec_mode  Sample program using cyclic synchronous position(csp) mode
-h, --help          Print this message and exit
End program
```